### PR TITLE
Fix/all images public

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -1,6 +1,6 @@
 import { Collection } from "@/components/shared/Collection"
 import { navLinks } from "@/constants"
-import { getAllImages } from "@/lib/actions/image.actions"
+import { getPublicImages } from "@/lib/actions/image.actions" // Use getPublicImages instead
 import Image from "next/image"
 import Link from "next/link"
 
@@ -8,7 +8,8 @@ const Home = async ({ searchParams }: SearchParamProps) => {
   const page = Number(searchParams?.page) || 1;
   const searchQuery = (searchParams?.query as string) || '';
 
-  const images = await getAllImages({ page, searchQuery})
+  // Only fetch public images for the homepage
+  const images = await getPublicImages({ page, searchQuery})
 
   return (
     <>

--- a/lib/actions/image.actions.ts
+++ b/lib/actions/image.actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { connectToDatabase } from "../database/mongoose";
 import { handleError } from "../utils";
 import User from "../database/models/user.model";
-import Image from "../database/models/image.model";
+import Image, { ImageQuery } from "../database/models/image.model";
 import { redirect } from "next/navigation";
 
 import { v2 as cloudinary } from 'cloudinary'
@@ -29,6 +29,7 @@ export async function addImage({ image, userId, path }: AddImageParams) {
     const newImage = await Image.create({
       ...image,
       author: author._id,
+      privacy: 'private' // Default to private
     })
 
     revalidatePath(path);
@@ -65,9 +66,20 @@ export async function updateImage({ image, userId, path }: UpdateImageParams) {
 }
 
 // DELETE IMAGE
-export async function deleteImage(imageId: string) {
+export async function deleteImage(imageId: string, userId: string) {
   try {
     await connectToDatabase();
+
+    // Check if user owns the image
+    const imageToDelete = await Image.findById(imageId);
+    
+    if (!imageToDelete) {
+      throw new Error("Image not found");
+    }
+    
+    if (imageToDelete.author.toHexString() !== userId) {
+      throw new Error("Unauthorized: You can only delete your own images");
+    }
 
     await Image.findByIdAndDelete(imageId);
   } catch (error) {
@@ -77,14 +89,22 @@ export async function deleteImage(imageId: string) {
   }
 }
 
-// GET IMAGE
-export async function getImageById(imageId: string) {
+// GET IMAGE (with privacy check)
+export async function getImageById(imageId: string, currentUserId?: string) {
   try {
     await connectToDatabase();
 
     const image = await populateUser(Image.findById(imageId));
 
-    if(!image) throw new Error("Image not found");
+    if (!image) throw new Error("Image not found");
+
+    // Check privacy: only show if public OR user owns the image
+    const isOwner = currentUserId && image.author._id.toString() === currentUserId;
+    const isPublic = image.privacy === 'public';
+
+    if (!isPublic && !isOwner) {
+      throw new Error("Unauthorized: This image is private");
+    }
 
     return JSON.parse(JSON.stringify(image));
   } catch (error) {
@@ -92,8 +112,8 @@ export async function getImageById(imageId: string) {
   }
 }
 
-// GET IMAGES
-export async function getAllImages({ limit = 9, page = 1, searchQuery = '' }: {
+// GET PUBLIC IMAGES (for homepage)
+export async function getPublicImages({ limit = 9, page = 1, searchQuery = '' }: {
   limit?: number;
   page: number;
   searchQuery?: string;
@@ -120,10 +140,12 @@ export async function getAllImages({ limit = 9, page = 1, searchQuery = '' }: {
 
     const resourceIds = resources.map((resource: any) => resource.public_id);
 
-    let query = {};
+    // Base query - only public images
+    let query: ImageQuery = { privacy: 'public' };
 
     if(searchQuery) {
       query = {
+        ...query,
         publicId: {
           $in: resourceIds
         }
@@ -150,7 +172,82 @@ export async function getAllImages({ limit = 9, page = 1, searchQuery = '' }: {
   }
 }
 
-// GET IMAGES BY USER
+// GET ALL IMAGES (admin only or for dashboard showing all user's own images)
+export async function getAllImages({ 
+  limit = 9, 
+  page = 1, 
+  searchQuery = '', 
+  userId,
+  showOnlyUserImages = false 
+}: {
+  limit?: number;
+  page: number;
+  searchQuery?: string;
+  userId?: string;
+  showOnlyUserImages?: boolean;
+}) {
+  try {
+    await connectToDatabase();
+
+    cloudinary.config({
+      cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+      api_key: process.env.CLOUDINARY_API_KEY,
+      api_secret: process.env.CLOUDINARY_API_SECRET,
+      secure: true,
+    })
+
+    let expression = 'folder=imaginify';
+
+    if (searchQuery) {
+      expression += ` AND ${searchQuery}`
+    }
+
+    const { resources } = await cloudinary.search
+      .expression(expression)
+      .execute();
+
+    const resourceIds = resources.map((resource: any) => resource.public_id);
+
+    let query: ImageQuery = {};
+
+    // If showing only user's images, filter by user
+    if (showOnlyUserImages && userId) {
+      query.author = userId;
+    } else {
+      // Otherwise, show only public images
+      query.privacy = 'public';
+    }
+
+    if(searchQuery) {
+      query = {
+        ...query,
+        publicId: {
+          $in: resourceIds
+        }
+      }
+    }
+
+    const skipAmount = (Number(page) -1) * limit;
+
+    const images = await populateUser(Image.find(query))
+      .sort({ updatedAt: -1 })
+      .skip(skipAmount)
+      .limit(limit);
+    
+    const totalImages = await Image.find(query).countDocuments();
+    const savedImages = await Image.find().countDocuments();
+
+    return {
+      data: JSON.parse(JSON.stringify(images)),
+      totalPage: Math.ceil(totalImages / limit),
+      savedImages,
+    }
+  } catch (error) {
+    handleError(error)
+  }
+}
+
+// GET IMAGES BY USER (user's own images - both public and private)
 export async function getUserImages({
   limit = 9,
   page = 1,
@@ -165,6 +262,7 @@ export async function getUserImages({
 
     const skipAmount = (Number(page) - 1) * limit;
 
+    // User can see all their own images (public and private)
     const images = await populateUser(Image.find({ author: userId }))
       .sort({ updatedAt: -1 })
       .skip(skipAmount)
@@ -176,6 +274,41 @@ export async function getUserImages({
       data: JSON.parse(JSON.stringify(images)),
       totalPages: Math.ceil(totalImages / limit),
     };
+  } catch (error) {
+    handleError(error);
+  }
+}
+
+// UPDATE IMAGE PRIVACY
+export async function updateImagePrivacy({ 
+  imageId, 
+  userId, 
+  privacy 
+}: { 
+  imageId: string; 
+  userId: string; 
+  privacy: 'public' | 'private' 
+}) {
+  try {
+    await connectToDatabase();
+
+    const image = await Image.findById(imageId);
+
+    if (!image) {
+      throw new Error("Image not found");
+    }
+
+    if (image.author.toHexString() !== userId) {
+      throw new Error("Unauthorized: You can only modify your own images");
+    }
+
+    const updatedImage = await Image.findByIdAndUpdate(
+      imageId,
+      { privacy },
+      { new: true }
+    );
+
+    return JSON.parse(JSON.stringify(updatedImage));
   } catch (error) {
     handleError(error);
   }

--- a/lib/database/models/image.model.ts
+++ b/lib/database/models/image.model.ts
@@ -22,6 +22,16 @@ export interface IImage extends Document {
   updatedAt?: Date;
 }
 
+
+// MongoDB query interface for type safety
+export interface ImageQuery {
+  privacy?: string;
+  author?: string;
+  publicId?: {
+    $in: string[];
+  };
+}
+
 const ImageSchema = new Schema({
   title: { type: String, required: true },
   transformationType: { type: String, required: true },

--- a/lib/database/models/image.model.ts
+++ b/lib/database/models/image.model.ts
@@ -12,6 +12,7 @@ export interface IImage extends Document {
   aspectRatio?: string;
   color?: string;
   prompt?: string;
+  privacy: 'private' | 'public';
   author: {
     _id: string;
     firstName: string;
@@ -33,6 +34,11 @@ const ImageSchema = new Schema({
   aspectRatio: { type: String },
   color: { type: String },
   prompt: { type: String },
+  privacy: { 
+    type: String, 
+    enum: ['private', 'public'], 
+    default: 'private'
+  },
   author: { type: Schema.Types.ObjectId, ref: 'User' },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }


### PR DESCRIPTION
- Add privacy field to Image model with enum validation (private/public)
- Default all new images to private for better security
- Implement authorization checks across all image operations:
  * getImageById: verify ownership or public status
  * deleteImage: ensure user owns image before deletion
  * updateImage: maintain existing ownership validation
- Create separate functions for public vs private image access:
  * getPublicImages: homepage gallery (public images only)
  * getUserImages: user profile (all owned images)
  * getAllImages: flexible function with privacy controls
- Add updateImagePrivacy function for users to change visibility
- Update Home component to use getPublicImages for security
- Replace 'any' types with proper ImageQuery interface for MongoDB queries
- Ensure all sensitive operations remain server-side with proper API key protection

BREAKING CHANGES:
- Images are now private by default (requires migration for existing images)
- deleteImage function signature changed to include userId parameter
- Home page now shows only public images instead of all images

Security improvements:
- Prevents unauthorized access to private user images
- Maintains server-side API key security
- Implements proper ownership validation for all CRUD operations